### PR TITLE
Definition of new function "get_waits"

### DIFF
--- a/lyse/__init__.py
+++ b/lyse/__init__.py
@@ -407,6 +407,22 @@ class Run(object):
             trace = h5_file['data']['traces'][name]
             return array(trace['t'],dtype=float),array(trace['values'],dtype=float)         
 
+    def get_waits(self):
+        """Return the time out status of waits.
+
+        Raises:
+            Exception: If the experiment has no waits.
+
+        Returns:
+            :obj:`numpy:numpy.ndarray`: Returns 2-D timetrace of times `'time'`
+            and time out status `'timed_out'`.
+        """
+        with h5py.File(self.h5_path,'r') as h5_file:
+            if not 'waits' in h5_file['data']:
+                raise Exception('The shot has no waits')
+            trace=h5_file['data']['waits']
+            return array((trace['time'],trace['timed_out']),dtype=float)  
+        
     def get_result_array(self,group,name):
         """Returns saved results data.
 


### PR DESCRIPTION
I defined a new function "get_waits". 
Returns a 2D array of times and timeout statuses.
This may be quite useful to some teams, where timeout signifies faulty experiment, and so unusable data.